### PR TITLE
Add pnpm catalogs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If an external rule is only used inside other rules/macros and not from `BUILD` 
 
 Each time dependencies change/get updated, run `pnpm install` (toolchains use `pnpm-lock.yaml`).
 
-**Note**: The NodeJS & Typescript versions you should use are dictated by [rules_js](https://github.com/aspect-build/rules_js) and [rules_ts](https://github.com/aspect-build/rules_ts). You can see more details, and where to check which versions are available, if you inspect the `WORKSPACE` file, I left some comments there.
+**Note**: The NodeJS, Typescript and PNPM maximum versions you should use are dictated by [rules_js](https://github.com/aspect-build/rules_js) and [rules_ts](https://github.com/aspect-build/rules_ts). You can see more details, and where to check which versions are available, if you inspect the `MODULE.bazel` file, I left some comments there.
 
 #### Development Requirements
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "devDependencies": {
     "@types/node": "24.10.1",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "chai": "catalog:",
+    "@types/chai": "catalog:"
   },
   "pnpm": {
     "onlyBuiltDependencies": []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,24 +4,53 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@types/chai':
+      specifier: 5.2.3
+      version: 5.2.3
+    chai:
+      specifier: 6.2.1
+      version: 6.2.1
+
 importers:
 
   .:
     devDependencies:
+      '@types/chai':
+        specifier: 'catalog:'
+        version: 5.2.3
       '@types/node':
-        specifier: 24.9.1
-        version: 24.9.1
+        specifier: 24.10.1
+        version: 24.10.1
+      chai:
+        specifier: 'catalog:'
+        version: 6.2.1
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.3
+        version: 5.9.3
 
 packages:
 
-  '@types/node@24.9.1':
-    resolution: {integrity: sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==, tarball: https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz}
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==, tarball: https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz}
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==, tarball: https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz}
+
+  '@types/node@24.10.1':
+    resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==, tarball: https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==, tarball: https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz}
+    engines: {node: '>=12'}
+
+  chai@6.2.1:
+    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==, tarball: https://registry.npmjs.org/chai/-/chai-6.2.1.tgz}
+    engines: {node: '>=18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -32,10 +61,21 @@ onlyBuiltDependencies: []
 
 snapshots:
 
-  '@types/node@24.9.1':
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/node@24.10.1':
     dependencies:
       undici-types: 7.16.0
 
-  typescript@5.8.3: {}
+  assertion-error@2.0.1: {}
+
+  chai@6.2.1: {}
+
+  typescript@5.9.3: {}
 
   undici-types@7.16.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - packages/*
+
+catalog:
+  chai: 6.2.1
+  "@types/chai": 5.2.3

--- a/src/ts/BUILD.bazel
+++ b/src/ts/BUILD.bazel
@@ -41,6 +41,8 @@ ts_project(
     deps = [
         ":c",
         "//:node_modules/@types/node",
+        "//:node_modules/chai",
+        "//:node_modules/@types/chai",
     ],
 )
 
@@ -48,8 +50,12 @@ js_test(
     name = "test_c",
     size = "small",
     data = [
-        "c.test.mjs",
+        # We could also use output files from the targets :c_test_lib and :c
+        # "c.test.mjs",
+        # "c.mjs",
+        ":c_test_lib",
         ":c",
+        "//:node_modules/chai",
     ],
     entry_point = "c.test.mjs",
 )

--- a/src/ts/c.test.mts
+++ b/src/ts/c.test.mts
@@ -1,4 +1,6 @@
-import assert from "node:assert";
+// Could simply use node assertions, but using chai for demonstration of a dependency
+// import assert from "node:assert";
+import { assert } from "chai";
 import { describe, it } from "node:test";
 import { sumNumbers } from "./c.mjs";
 


### PR DESCRIPTION
This PR adds a small example of [pnpm catalogs](https://pnpm.io/catalogs), by adding the [Chai](https://www.chaijs.com/) assertion library.

With this experiment I learned that pnpm catalogs are implicitly supported by `rules_js`, as the catalog items resolution happens inside the pnpm lockfile (which is what `rules_js` checks). `rules_js` only does one check related with `specifier` lockfile attributes, check if they start with `npm:`, to detect package aliases.