### PR TITLE
chore(deps): bump rules_js to 3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Must-have for JS
-bazel_dep(name = "aspect_rules_js", version = "3.0.0-rc5")
+bazel_dep(name = "aspect_rules_js", version = "3.0.0-rc6")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 # NodeJS version dependant on rules_nodejs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Must-have for JS
-bazel_dep(name = "aspect_rules_js", version = "2.9.2")
+bazel_dep(name = "aspect_rules_js", version = "3.0.0-rc5")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 # NodeJS version dependant on rules_nodejs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # Must-have for JS
-bazel_dep(name = "aspect_rules_js", version = "3.0.0-rc6")
+bazel_dep(name = "aspect_rules_js", version = "3.0.0")
 
 node = use_extension("@rules_nodejs//nodejs:extensions.bzl", "node", dev_dependency = True)
 # NodeJS version dependant on rules_nodejs
@@ -43,7 +43,7 @@ pnpm.pnpm(
 )
 
 # Must-have for TS
-bazel_dep(name = "aspect_rules_ts", version = "3.8.4")
+bazel_dep(name = "aspect_rules_ts", version = "3.8.5")
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
 # TypeScript version dependant on rules_ts
 # https://github.com/aspect-build/rules_ts/releases/latest -> ts/private/versions.bzl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .DEFAULT_GOAL := run
 
+all: test run
+.PHONY: all
+
 run:
 	bazel run //src/js:run_b
 	bazel run //src/ts:run_d


### PR DESCRIPTION
- Bumps `rules_js` to 3.0
- Bumps `rules_ts` to 3.8.5
- Adds a `make all` command that first runs tests, then all the runnable actions (`make run`)